### PR TITLE
feat: Update ar_dataset codes applying padding logic

### DIFF
--- a/config/example_llama3.1_full.yaml
+++ b/config/example_llama3.1_full.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: True
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/example_llama3.1_lora.yaml
+++ b/config/example_llama3.1_lora.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: True
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/example_llama3.1_qlora.yaml
+++ b/config/example_llama3.1_qlora.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: True
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_gemma2_full_fsdp.yaml
+++ b/config/llm_gemma2_full_fsdp.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_gemma2_lora.yaml
+++ b/config/llm_gemma2_lora.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_gemma2_qlora.yaml
+++ b/config/llm_gemma2_qlora.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_gemma_full_fsdp.yaml
+++ b/config/llm_gemma_full_fsdp.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_gemma_lora.yaml
+++ b/config/llm_gemma_lora.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_gemma_qlora.yaml
+++ b/config/llm_gemma_qlora.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_llama2_full_fsdp.yaml
+++ b/config/llm_llama2_full_fsdp.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_llama2_lora.yaml
+++ b/config/llm_llama2_lora.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_llama2_qlora.yaml
+++ b/config/llm_llama2_qlora.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_llama3.1_70B_lora_fsdp.yaml
+++ b/config/llm_llama3.1_70B_lora_fsdp.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_llama3.1_full.yaml
+++ b/config/llm_llama3.1_full.yaml
@@ -2,7 +2,7 @@
 seed: 0
 deterministic: True
 model: meta-llama/Llama-3.1-8B-Instruct
-model_cache_dir: /home/data_storage/huggingface/
+model_cache_dir: null
 
 # data config
 data_train_type: ['ar']
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_llama3.1_lora.yaml
+++ b/config/llm_llama3.1_lora.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_llama3.1_qlora.yaml
+++ b/config/llm_llama3.1_qlora.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_llama3_full.yaml
+++ b/config/llm_llama3_full.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_llama3_lora.yaml
+++ b/config/llm_llama3_lora.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_llama3_qlora.yaml
+++ b/config/llm_llama3_qlora.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_phi3_full.yaml
+++ b/config/llm_phi3_full.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_phi3_lora.yaml
+++ b/config/llm_phi3_lora.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_phi3_qlora.yaml
+++ b/config/llm_phi3_qlora.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_qwen3_full.yaml
+++ b/config/llm_qwen3_full.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: False
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_qwen3_lora.yaml
+++ b/config/llm_qwen3_lora.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: False
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/config/llm_qwen3_qlora.yaml
+++ b/config/llm_qwen3_qlora.yaml
@@ -34,8 +34,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: False
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/docs/3_training.md
+++ b/docs/3_training.md
@@ -45,8 +45,6 @@ fsdp_hyperparameters:
 # data config
 max_length: 8192
 is_multi_turn: False
-add_bos_token_when_response_start: True
-add_eos_token_when_response_end: True
 data_verbose: False
 
 # tokenizer config (I recommend to double check the tokenizer's special token map)

--- a/src/univlt/data_collection/ar_dataset.py
+++ b/src/univlt/data_collection/ar_dataset.py
@@ -188,7 +188,7 @@ class AutoregressiveDataset(Dataset):
 
         # When pad_token_id == eos_token_id, padding positions use EOS tokens
         # set to ignore_index so CrossEntropyLoss(ignore_index=ignore_index) excludes them from loss
-        if self.pad_token_id == self.tokenizer.eos_token_id:
+        if self.pad_token_id == self.eos_token_id:
             label[data_len:self.max_length] = [self.ignore_index] * (self.max_length - data_len)
         
         assert len(full_prompt_token) == len(attention_mask) == len(label) == self.max_length, \

--- a/src/univlt/data_collection/ar_dataset.py
+++ b/src/univlt/data_collection/ar_dataset.py
@@ -1,8 +1,8 @@
 import os
-import random
 from tqdm import tqdm
 from copy import deepcopy
 import matplotlib.pyplot as plt
+from typing import Tuple
 
 import torch
 from torch.utils.data import Dataset
@@ -16,26 +16,30 @@ from univlt.utils.filesys_utils import txt_load, json_load
 class AutoregressiveDataset(Dataset):
     def __init__(
             self,
-            mode,
+            mode: str,
             cfg: TrainingConfig,
-            data, 
+            data: list[dict], 
             tokenizer,
             template_path=None,
             name=None
         ):
-        # init
+        """
+        Initialize an Autoregressive dataset.
+
+        Args:
+            mode (str): Dataset split (e.g., "train", "validation", "test").
+            cfg (TrainingConfig): Training configuration.
+            data (list[dict]): Raw dataset samples.
+            tokenizer (CustomTokenizer): Tokenizer used for encoding text.
+            template_path (None): Path to the prompt template file. (Unused)
+            name (None): Dataset name for logging/visualization. (Unused)
+        """
+        # Initialize variables
         name = 'Autoregressive' if not name else name
         self.data = data
         self.tokenizer = tokenizer
-        self.pad_token_id = self.tokenizer.pad_token_id
-        
-        # read data and template
-        self.template = json_load(template_path)
-
-        # params
+        self.__init_tokens()
         self.max_length = cfg.max_length
-        self.add_bos = cfg.data_cfg.add_bos_token_when_response_start
-        self.add_eos = cfg.data_cfg.add_eos_token_when_response_end
         self.verbose = cfg.data_cfg.data_verbose
         self.length = len(self.data)
 
@@ -61,63 +65,111 @@ class AutoregressiveDataset(Dataset):
             plt.tight_layout()
             plt.savefig(os.path.join(save_dir, f'{name}_{mode}_data_hist.png'), dpi=300)
 
-    
-    def get_token_len_statistics(self, data):
+    def __init_tokens(self):
         """
-        Args:
-            data (list): list of str.
+        Initialize EOS and PAD tokens and their IDs.
+
+        If either EOS or PAD token is missing, it is inferred from the other.
+        At least one of them must exist.
+
+        Raises:
+            AssertionError: At least one of `eos_token_id` and `pad_token_id` must exist.
+        """
+        self.eos_token, self.eos_token_id = self.tokenizer.eos_token, self.tokenizer.eos_token_id
+        self.pad_token, self.pad_token_id = self.tokenizer.pad_token, self.tokenizer.pad_token_id
+        self.ignore_index = -100
+
+        if self.pad_token_id is None and self.eos_token_id is not None:
+            self.pad_token_id = self.eos_token_id
+            self.pad_token = self.eos_token
+        elif self.pad_token_id is not None and self.eos_token_id is None:
+            self.eos_token_id = self.pad_token_id
+            self.eos_token = self.pad_token
+        elif self.pad_token_id is None and self.eos_token_id is None:
+            raise AssertionError(colorstr('red', 'Both `eos_token_id` and `pad_token_id` are not existing.'))
+        
+        # If bos_token_id is not None, use it, otherwise use pad_token_id
+        if self.tokenizer.bos_token_id is not None:
+            self.bos_token_id = self.tokenizer.bos_token_id
+            self.bos_token = self.tokenizer.bos_token
+        else:
+            self.bos_token_id = self.pad_token_id
+            self.bos_token = self.pad_token
+    
+    def get_token_len_statistics(self) -> Tuple[list[int], int, int, float]:
+        """
+        Calculate token length statistics for the dataset.
+
+        Returns:
+            Tuple[list, int, int, float]: A tuple containing the list of token lengths, maximum length, minimum length, and average length.
         """
         max_n = 200000
-        interv = len(data) // max_n if len(data) > max_n else 1
+        interv = len(self.data) // max_n if len(self.data) > max_n else 1
         if interv > 1:
-            log(f"Length of {len(data)} is too long. Approximately {len(data) // interv} samples will be used to calculate statistics.", level='warning')
-        length = [len(self.make_ar_data(i)[0]) for i in tqdm(range(0, len(data), interv))]
+            log(f"Length of {len(self.data)} is too long. Approximately {len(self.data) // interv} samples will be used to calculate statistics.", level='warning')
+        length = [len(self.make_ar_data(i)[0]) for i in tqdm(range(0, len(self.data), interv))]
         max_length = max(length)
         min_length = min(length)
         avg_length = sum(length) / len(length)
         return length, max_length, min_length, avg_length
     
 
-    def make_ar_data(self, idx):
+    def make_ar_data(self, idx: int) -> Tuple[list[int], str]:
+        """
+        Prepare a formatted prompt and corresponding token IDs for a given data sample.
+
+        Args:
+            idx (int): Index of the data sample to process.
+
+        Returns:
+            Tuple[list[int], str]: A tuple containing the list of input token IDs and formatted prompt string.
+        """
         single_data = self.data[idx]
-        template = self.template['system_prompt_template']
-        
+
         # Assume the data has the single key 'text' for user prompt
-        system_prompt = None
-        user_prompt = single_data['text'][0]
-        formatted_prompt = template.format(
-            system_prompt='' if system_prompt is None else system_prompt,
-            user_prompt=user_prompt
-        )
+        formatted_prompt = self.bos_token + single_data['text'][0] + self.eos_token
+
         full_prompt_tokens = self.tokenizer.encode(formatted_prompt)
 
         return full_prompt_tokens, formatted_prompt
         
 
-    def _pad(self, data, max_length, pad_token_id, bos_token=None, eos_token=None, return_data_len=False, bos_masking=False):
-        # add bos and eos token
-        if bos_token:
-            data = [self.tokenizer.pad_token_id] + data if bos_masking else [self.tokenizer.bos_token_id] + data
-        if eos_token:
-            data.append(self.tokenizer.eos_token_id)
-        
+    def _pad(self, data: list[int], max_length: int, pad_token_id: int) -> Tuple[list[int], int]:
+        """
+        Pad the input data to a specified maximum length using a given padding token ID.
+
+        Args:
+            data (list[int]): List of token IDs to be padded.
+            max_length (int): Maximum length to pad the data to.
+            pad_token_id (int): Token ID to use for padding.
+
+        Returns:
+            Tuple[list[int], int]: A tuple containing the padded list of token IDs and the original length of the data before padding.
+        """
         # calculate data length
         data = data if len(data) <= max_length else data[:max_length]
         data_len = len(data)
 
         # padding
         data = data + [pad_token_id] * (max_length - len(data))
-        if return_data_len:
-            return data, data_len
-        return data
+        return data, data_len
     
 
     @staticmethod
-    def get_mask(token_length):
+    def get_mask(token_length: int):
+        """
+        Get attention mask.
+
+        Args:
+            token_length (int): Token length to do attention.
+
+        Returns:
+            list[int]: Attention mask.
+        """
         return [1] * token_length
     
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: int):
         full_prompt_token, formatted_prompt = self.make_ar_data(idx)
         
         # padding
@@ -125,18 +177,22 @@ class AutoregressiveDataset(Dataset):
             data=full_prompt_token,
             max_length=self.max_length,
             pad_token_id=self.pad_token_id,
-            bos_token=self.tokenizer.bos_token_id if self.add_bos and self.tokenizer.bos_token_id else None,
-            eos_token=self.tokenizer.eos_token_id if self.add_eos and self.tokenizer.eos_token_id else None,
-            return_data_len=True
         )
-        attention_mask = self._pad(self.get_mask(data_len), self.max_length, 0)
+        attention_mask, _ = self._pad(
+            data=self.get_mask(data_len),
+            max_length=self.max_length,
+            pad_token_id=0,
+        )
 
-        if self.add_bos:
-            formatted_prompt = self.tokenizer.bos_token + formatted_prompt
-        if self.add_eos:
-            formatted_prompt = formatted_prompt + self.tokenizer.eos_token
+        label = deepcopy(full_prompt_token)
 
-        label = deepcopy(full_prompt_token)        
+        # When pad_token_id == eos_token_id, padding positions use EOS tokens
+        # set to ignore_index so CrossEntropyLoss(ignore_index=ignore_index) excludes them from loss
+        if self.pad_token_id == self.tokenizer.eos_token_id:
+            label[data_len:self.max_length] = [self.ignore_index] * (self.max_length - data_len)
+        
+        assert len(full_prompt_token) == len(attention_mask) == len(label) == self.max_length, \
+            f'Length of full_prompt_token, attention_mask, label are not same: {len(full_prompt_token)}, {len(attention_mask)}, {len(label)}'
 
         return {'src': torch.tensor(full_prompt_token, dtype=torch.long), 'src_attention_mask': torch.tensor(attention_mask, dtype=torch.long),
                 'label': torch.tensor(label, dtype=torch.long),


### PR DESCRIPTION
pad_token_id == eos_token_id == 2 일 때,

* input_ids
A: [10, 11, 12, 13, 14, 2]
B: [20, 21, 22, 2, 2, 2] ← (여기서 뒤의 2들은 padding 역할)

* attention_mask
A: [1, 1, 1, 1, 1, 1] ← 마지막 eos는 “진짜 eos”
B: [1, 1, 1, 1, 0, 0] ← 뒤의 eos들은 “padding eos”

* labels (padding의 역할을 하는 eos 제외)
A: [..., 14, 2]
B: [..., 2, -100, -100]

* 주의 `return self.tokenizer.encode(s, add_special_tokens=False)`

맨 앞 <bos> 토큰 이용, 데이터 뒷부분에 <eos> 토큰 이용. pad_token_id와 eos_token_id가 같다면 ignore_index (-100)를 사용하여 구분할 수 있도록 함.
config에도 add_bos_token_when_response_start, add_eos_token_when_response_end 제거.